### PR TITLE
CLI to create tables based on JSON schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Usage
 =====
 
 The module ``create_db.py`` contains functions for feeding data into a SQLite database.
+A command-line interface is provided via the command ``create-db``.
 
 
 Installation

--- a/datavisapp/create_db.py
+++ b/datavisapp/create_db.py
@@ -1,5 +1,8 @@
+import json
 import sqlite3
+from collections import OrderedDict
 
+import click as click
 import pandas as pd
 
 
@@ -12,6 +15,7 @@ def make_table(db, table_name, col_types):
         columns.append(col_str)
     columns = ', '.join(columns)
     query = f'''create table {table_name} ({columns})'''
+    click.echo(f'Creating table {table_name} with SQL command:\n{query}', err=True)
     cursor.execute(query)
     conn.close()
 
@@ -21,3 +25,27 @@ def append_csv_to_table(db, table_name, csv_path):
     df = pd.read_csv(csv_path)
     df.to_sql(table_name, conn, if_exists='append', index=False)
     conn.close()
+
+
+def create_db(db, schema_json):
+    """Create a database according to schema in JSON format."""
+    with open(schema_json) as of:
+        schema = json.load(of, object_pairs_hook=OrderedDict)
+        # OrderedDict so that tables are created in the order specified,
+        # allowing foreign keys to reference previously defined tables
+
+    for table_name, columns in schema.items():
+        col_types = columns.items()  # dict -> tuple
+        make_table(db, table_name, col_types)
+
+
+@click.command()
+@click.argument('db_path')
+@click.argument('schema_json')
+def main(db_path, schema_json):
+    """Create a database from a schema and populate it with CSV/JSON data.
+
+    The schema is supplied as a JSON file with the following structure:
+    {"<table name>": {"<field name>": "<field type> <constraints>"}}
+    """
+    create_db(db_path, schema_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click==6.7
 numpy==1.13.3
 pandas==0.20.3
 python-dateutil==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     packages=['datavisapp'],
 
     install_requires=[
+        'click',
         'pandas',
     ],
 
@@ -23,4 +24,9 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
+    entry_points={
+        'console_scripts': [
+            'create-db = datavisapp.create_db:main',
+        ],
+    },
 )

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "DataSet": "TEXT PRIMARY KEY",
+    "Date": "TEXT"
+  },
+  "metrics": {
+    "Sample": "TEXT",
+    "MetricA": "FLOAT",
+    "MetricB": "FLOAT",
+    "DataSet": "TEXT",
+    "FOREIGN KEY(DataSet)": "REFERENCES metadata(DataSet)"
+  }
+}

--- a/tests/test_create_db.py
+++ b/tests/test_create_db.py
@@ -1,7 +1,9 @@
 import sqlite3
 from pathlib import Path
 
-from datavisapp.create_db import make_table, append_csv_to_table
+from click.testing import CliRunner
+
+from datavisapp.create_db import make_table, append_csv_to_table, main
 
 
 def test_make_table(tmpdir):
@@ -45,4 +47,23 @@ def test_append_csv_to_table(tmpdir):
         ('S02', 0.9, 45.0),
         ('S01', 0.7, 10.0),
         ('S02', 0.9, 20.0),
+    ]
+
+
+def test_create_db(tmpdir):
+    db = str(tmpdir.join('test.db'))
+    schema_json = str(Path('tests', 'schema.json'))
+
+    runner = CliRunner()
+    result = runner.invoke(main, [db, schema_json])
+    assert result.exit_code == 0
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("select name from sqlite_master where type = 'table'")
+        existing_tables = cursor.fetchall()
+
+    assert existing_tables == [
+        ('metadata',),
+        ('metrics',),
     ]


### PR DESCRIPTION
A command-line interface to the create_db module has been added to
allow the database to be created in a single command by passing in the
schema in JSON format.
This can be expanded to also load data into the newly created database
from CSV/JSON files.